### PR TITLE
import reduce from functools, for python 3 compatibility

### DIFF
--- a/uwsgicachetop
+++ b/uwsgicachetop
@@ -12,6 +12,7 @@ import atexit
 import sys
 import traceback
 from collections import defaultdict
+from functools import reduce
 
 need_reset = True
 screen = None


### PR DESCRIPTION
The builtin `reduce` has moved to `functools.reduce` in Python 3. Adding this import also works in Python 2.7.x.
